### PR TITLE
perf: Optimize deploy pipeline with parallel builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,17 +15,19 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-and-push:
-    name: Build and push Docker images
+  # Job paralleli per build delle immagini
+  build-payload:
+    name: Build Payload image
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     outputs:
       commit_sha: ${{ steps.vars.outputs.sha_short }}
+      repo_owner: ${{ steps.vars.outputs.repo_owner_lowercase }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -54,8 +56,34 @@ jobs:
             ${{ env.REGISTRY }}/${{ steps.vars.outputs.repo_owner_lowercase }}/lemmario-payload:sha-${{ steps.vars.outputs.sha_short }}
           build-args: |
             PAYLOAD_PUBLIC_SERVER_URL=https://glossari.dh.unica.it
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=payload
+          cache-to: type=gha,mode=max,scope=payload
+
+  build-frontend:
+    name: Build Frontend image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata and commit SHA
+        id: vars
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "repo_owner_lowercase=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Build and push Frontend image
         uses: docker/build-push-action@v5
@@ -66,13 +94,13 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ steps.vars.outputs.repo_owner_lowercase }}/lemmario-frontend:latest
             ${{ env.REGISTRY }}/${{ steps.vars.outputs.repo_owner_lowercase }}/lemmario-frontend:sha-${{ steps.vars.outputs.sha_short }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend
 
   deploy:
     name: Deploy to VPN server
     runs-on: self-hosted
-    needs: build-and-push
+    needs: [build-payload, build-frontend]
     environment: production
     permissions:
       contents: read
@@ -99,7 +127,7 @@ jobs:
 
       - name: Deploy with script
         run: |
-          /home/dhruby/deploy-lemmario.sh ${{ needs.build-and-push.outputs.commit_sha }}
+          /home/dhruby/deploy-lemmario.sh ${{ needs.build-payload.outputs.commit_sha }}
 
       - name: Cleanup temporary checkout
         if: always()

--- a/docs/DEPLOY-OPTIMIZATION-PLAN.md
+++ b/docs/DEPLOY-OPTIMIZATION-PLAN.md
@@ -1,0 +1,150 @@
+# Piano di Ottimizzazione Deploy
+
+**Data**: 2026-02-03
+**Obiettivo**: Ridurre il tempo di deploy da ~12-18 minuti a ~7-11 minuti
+
+## Analisi Stato Attuale
+
+### Flusso di Deploy Corrente
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ CI Workflow (~4-6 min)                                                  │
+│ Checkout → pnpm setup → Install deps → Lint → Typecheck → Build        │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    ↓
+┌─────────────────────────────────────────────────────────────────────────┐
+│ CD Workflow - Build (~5-8 min) ❌ SEQUENZIALE                           │
+│ Setup Buildx → Build Payload (~3-4 min) → Build Frontend (~2-3 min)    │
+└─────────────────────────────────────────────────────────────────────────┘
+                                    ↓
+┌─────────────────────────────────────────────────────────────────────────┐
+│ CD Workflow - Deploy (~3-4 min)                                         │
+│ Clone repo → Copy script → Pull images → Health Checks (max 2min)      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Problemi Identificati
+
+| # | Problema | Impatto | Tempo Perso |
+|---|----------|---------|-------------|
+| 1 | Build Docker sequenziali | ALTO | ~3-4 min |
+| 2 | CI build non riutilizzato | MEDIO | ~2-3 min |
+| 3 | pnpm installato 4 volte nei Dockerfile | MEDIO | ~1-2 min |
+| 4 | Layer caching Dockerfile non ottimale | MEDIO | ~1 min |
+| 5 | Pull images sequenziale nello script | BASSO | ~30s |
+| 6 | Health checks troppo conservativi | BASSO | ~1 min avg |
+
+## Piano di Implementazione
+
+### Fase 1: Build Parallelo (Priorità ALTA)
+
+**Risparmio stimato**: ~3-4 minuti
+
+**Modifica**: Separare il job `build-and-push` in due job paralleli.
+
+**File**: `.github/workflows/deploy.yml`
+
+```yaml
+jobs:
+  build-payload:
+    name: Build Payload image
+    runs-on: ubuntu-latest
+    outputs:
+      commit_sha: ${{ steps.vars.outputs.sha_short }}
+    steps:
+      # Build solo Payload
+
+  build-frontend:
+    name: Build Frontend image
+    runs-on: ubuntu-latest
+    steps:
+      # Build solo Frontend (parallelo a Payload)
+
+  deploy:
+    needs: [build-payload, build-frontend]
+    # Aspetta entrambi prima di deployare
+```
+
+### Fase 2: Ottimizzazione Dockerfile (Priorità MEDIA)
+
+**Risparmio stimato**: ~1-2 minuti
+
+**Modifica**: Riordinare i layer per massimizzare il cache hit.
+
+**Principio**: Copiare prima i file che cambiano raramente (lockfile), poi quelli che cambiano spesso (codice).
+
+```dockerfile
+# PRIMA: file di dipendenze (cambiano raramente)
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/payload-cms/package.json ./packages/payload-cms/
+RUN pnpm install --frozen-lockfile
+
+# DOPO: codice sorgente (cambia spesso)
+COPY packages/payload-cms ./packages/payload-cms
+RUN pnpm build
+```
+
+### Fase 3: Ottimizzazione Deploy Script (Priorità BASSA)
+
+**Risparmio stimato**: ~1 minuto
+
+**Modifiche**:
+1. Pull immagini in parallelo con `&` e `wait`
+2. Health checks più aggressivi all'inizio
+
+```bash
+# Pull parallelo
+docker pull "$REGISTRY/payload:$SHA" &
+docker pull "$REGISTRY/frontend:$SHA" &
+wait
+
+# Health checks: 6 tentativi rapidi (2s), poi 10 lenti (5s)
+```
+
+## Confronto Tempi Attesi
+
+| Fase | Attuale | Dopo Ottimizzazione |
+|------|---------|---------------------|
+| CI | 4-6 min | 4-6 min |
+| Build Docker | 5-8 min | **2-4 min** |
+| Deploy | 3-4 min | **2-3 min** |
+| **Totale** | **12-18 min** | **8-13 min** |
+
+## Implementazione
+
+### Modifiche ai File
+
+1. **`.github/workflows/deploy.yml`**
+   - Separare build in job paralleli
+   - Mantenere deploy come job dipendente
+
+2. **`packages/payload-cms/Dockerfile`**
+   - Riordinare COPY per cache optimization
+
+3. **`packages/frontend/Dockerfile`**
+   - Riordinare COPY per cache optimization
+
+4. **`scripts/deploy/deploy-lemmario.sh`**
+   - Parallelizzare pull images
+   - Ottimizzare health checks
+
+### Verifica
+
+1. Push su branch `main`
+2. Monitorare GitHub Actions
+3. Verificare tempi di esecuzione
+4. Confermare deploy su server VPN
+
+## Rollback
+
+In caso di problemi:
+- Il workflow precedente è nel git history
+- Le immagini Docker precedenti sono su GHCR con tag `sha-*`
+- Lo script di deploy ha rollback automatico
+
+## Note
+
+- Le ottimizzazioni sono incrementali e possono essere applicate separatamente
+- La Fase 1 (build parallelo) offre il miglior rapporto costo/beneficio
+- Future ottimizzazioni potrebbero includere il riutilizzo degli artifact CI

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -6,21 +6,20 @@ RUN npm install -g pnpm@8.15.1
 # Set working directory
 WORKDIR /app
 
-# Copy workspace files
+# LAYER CACHING OPTIMIZATION:
+# Step 1: Copy only dependency files (change rarely)
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY package.json ./
-COPY tsconfig.json ./
-
-# Copy frontend package
 COPY packages/frontend/package.json ./packages/frontend/
 
-# Install dependencies
+# Step 2: Install dependencies (cached if lockfile unchanged)
 RUN pnpm install --frozen-lockfile
 
-# Copy source code
+# Step 3: Copy source code (changes frequently)
+COPY tsconfig.json ./
 COPY packages/frontend ./packages/frontend
 
-# Build
+# Step 4: Build
 WORKDIR /app/packages/frontend
 RUN pnpm build
 

--- a/packages/payload-cms/Dockerfile
+++ b/packages/payload-cms/Dockerfile
@@ -14,18 +14,20 @@ ARG DATABASE_URI=postgres://localhost:5432/lemmario_db
 ENV PAYLOAD_PUBLIC_SERVER_URL=${PAYLOAD_PUBLIC_SERVER_URL}
 ENV DATABASE_URI=${DATABASE_URI}
 
-# Copy workspace files
+# LAYER CACHING OPTIMIZATION:
+# Step 1: Copy only dependency files (change rarely)
 COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY package.json ./
-COPY tsconfig.json ./
+COPY packages/payload-cms/package.json ./packages/payload-cms/
 
-# Copy payload package
-COPY packages/payload-cms ./packages/payload-cms
-
-# Install ALL dependencies (including dev for build)
+# Step 2: Install dependencies (cached if lockfile unchanged)
 RUN pnpm install --frozen-lockfile
 
-# Build TypeScript and Payload Admin panel
+# Step 3: Copy source code (changes frequently)
+COPY tsconfig.json ./
+COPY packages/payload-cms ./packages/payload-cms
+
+# Step 4: Build TypeScript and Payload Admin panel
 WORKDIR /app/packages/payload-cms
 RUN pnpm build && npx payload build
 

--- a/scripts/deploy/deploy-lemmario.sh
+++ b/scripts/deploy/deploy-lemmario.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# deploy-lemmario.sh - Deploy script per Lemmario
+# deploy-lemmario.sh - Deploy script per Lemmario (OTTIMIZZATO)
 # Usage: ./deploy-lemmario.sh <commit-sha>
 #
 # IMPORTANTE: Questo script deve essere copiato sul server VPN in /home/dhruby/deploy-lemmario.sh
@@ -14,11 +14,15 @@ COMPOSE_FILE="/home/dhruby/lemmario-ts/docker-compose.yml"
 COMPOSE_PROD_FILE="/home/dhruby/lemmario-ts/docker-compose.prod.yml"
 PROJECT_DIR="/home/dhruby/lemmario-ts"
 GHCR_REGISTRY="ghcr.io/unica-dh"  # es. ghcr.io/unica-dh
-HEALTH_CHECK_RETRIES=24
-HEALTH_CHECK_INTERVAL=5
+
+# Health check ottimizzati: prima veloci, poi lenti
+HEALTH_CHECK_FAST_RETRIES=6
+HEALTH_CHECK_FAST_INTERVAL=2
+HEALTH_CHECK_SLOW_RETRIES=12
+HEALTH_CHECK_SLOW_INTERVAL=5
 
 echo "=========================================="
-echo "Lemmario Deploy - $(date)"
+echo "Lemmario Deploy (Optimized) - $(date)"
 echo "Commit SHA: $COMMIT_SHA"
 echo "=========================================="
 
@@ -55,10 +59,17 @@ $COMPOSE_CMD -f "$COMPOSE_FILE" exec -T postgres pg_dump \
   }
 echo "Backup saved to: $BACKUP_DIR/lemmario_db.sql"
 
-# Step 2: Pull nuove images da GHCR
-echo "[2/9] Pulling new images from GHCR..."
-docker pull "$GHCR_REGISTRY/lemmario-payload:sha-$COMMIT_SHA"
-docker pull "$GHCR_REGISTRY/lemmario-frontend:sha-$COMMIT_SHA"
+# Step 2: Pull nuove images da GHCR (PARALLELO)
+echo "[2/9] Pulling new images from GHCR (parallel)..."
+docker pull "$GHCR_REGISTRY/lemmario-payload:sha-$COMMIT_SHA" &
+PID_PAYLOAD=$!
+docker pull "$GHCR_REGISTRY/lemmario-frontend:sha-$COMMIT_SHA" &
+PID_FRONTEND=$!
+
+# Attendi entrambi i pull
+wait $PID_PAYLOAD || { echo "ERROR: Failed to pull payload image"; exit 1; }
+wait $PID_FRONTEND || { echo "ERROR: Failed to pull frontend image"; exit 1; }
+echo "Images pulled successfully!"
 
 # Step 3: Stop servizi (preserva volumi)
 echo "[3/9] Stopping services..."
@@ -78,56 +89,81 @@ EOF
 # Step 5: Ensure postgres is up and healthy
 echo "[5/9] Ensuring postgres is healthy..."
 $COMPOSE_CMD -f "$COMPOSE_FILE" up -d postgres
-# Wait for postgres to be healthy
-for i in $(seq 1 $HEALTH_CHECK_RETRIES); do
+
+# Health check veloce per postgres
+for i in $(seq 1 $HEALTH_CHECK_FAST_RETRIES); do
   if $COMPOSE_CMD -f "$COMPOSE_FILE" exec -T postgres pg_isready -U lemmario_user -d lemmario_db 2>/dev/null; then
     echo "Postgres is healthy!"
     break
   fi
-  if [ $i -eq $HEALTH_CHECK_RETRIES ]; then
-    echo "ERROR: Postgres health check failed"
-    exit 1
+  if [ $i -eq $HEALTH_CHECK_FAST_RETRIES ]; then
+    # Fallback a check lenti
+    echo "Fast check failed, trying slow checks..."
+    for j in $(seq 1 $HEALTH_CHECK_SLOW_RETRIES); do
+      if $COMPOSE_CMD -f "$COMPOSE_FILE" exec -T postgres pg_isready -U lemmario_user -d lemmario_db 2>/dev/null; then
+        echo "Postgres is healthy!"
+        break 2
+      fi
+      if [ $j -eq $HEALTH_CHECK_SLOW_RETRIES ]; then
+        echo "ERROR: Postgres health check failed"
+        exit 1
+      fi
+      echo "Waiting for postgres... (slow $j/$HEALTH_CHECK_SLOW_RETRIES)"
+      sleep $HEALTH_CHECK_SLOW_INTERVAL
+    done
   fi
-  echo "Waiting for postgres... ($i/$HEALTH_CHECK_RETRIES)"
-  sleep $HEALTH_CHECK_INTERVAL
+  echo "Waiting for postgres... (fast $i/$HEALTH_CHECK_FAST_RETRIES)"
+  sleep $HEALTH_CHECK_FAST_INTERVAL
 done
 
 # Step 6: Start servizi con nuove images (senza ricreare postgres)
 echo "[6/9] Starting services with new images..."
 $COMPOSE_CMD -f "$COMPOSE_FILE" -f "$COMPOSE_PROD_FILE" up -d --no-deps payload frontend
 
+# Funzione helper per health check a due fasi
+health_check() {
+  local service_name="$1"
+  local check_cmd="$2"
+
+  # Fase 1: check veloci
+  for i in $(seq 1 $HEALTH_CHECK_FAST_RETRIES); do
+    if eval "$check_cmd"; then
+      echo "$service_name is healthy!"
+      return 0
+    fi
+    echo "Waiting for $service_name... (fast $i/$HEALTH_CHECK_FAST_RETRIES)"
+    sleep $HEALTH_CHECK_FAST_INTERVAL
+  done
+
+  # Fase 2: check lenti
+  echo "Fast checks failed for $service_name, trying slow checks..."
+  for i in $(seq 1 $HEALTH_CHECK_SLOW_RETRIES); do
+    if eval "$check_cmd"; then
+      echo "$service_name is healthy!"
+      return 0
+    fi
+    echo "Waiting for $service_name... (slow $i/$HEALTH_CHECK_SLOW_RETRIES)"
+    sleep $HEALTH_CHECK_SLOW_INTERVAL
+  done
+
+  return 1
+}
+
 # Step 7: Health check payload
 echo "[7/9] Health checking payload service..."
-for i in $(seq 1 $HEALTH_CHECK_RETRIES); do
-  if curl -sf http://localhost:3000/api/access >/dev/null 2>&1; then
-    echo "Payload is healthy!"
-    break
-  fi
-  if [ $i -eq $HEALTH_CHECK_RETRIES ]; then
-    echo "ERROR: Payload health check failed after $HEALTH_CHECK_RETRIES retries"
-    echo "[ROLLBACK] Reverting to previous version..."
-    # Rollback: restart con immagini precedenti
-    $COMPOSE_CMD -f "$COMPOSE_FILE" restart payload frontend
-    exit 1
-  fi
-  echo "Waiting for payload... ($i/$HEALTH_CHECK_RETRIES)"
-  sleep $HEALTH_CHECK_INTERVAL
-done
+if ! health_check "Payload" "curl -sf http://localhost:3000/api/access >/dev/null 2>&1"; then
+  echo "ERROR: Payload health check failed"
+  echo "[ROLLBACK] Reverting to previous version..."
+  $COMPOSE_CMD -f "$COMPOSE_FILE" restart payload frontend
+  exit 1
+fi
 
 # Step 8: Health check frontend
 echo "[8/9] Health checking frontend service..."
-for i in $(seq 1 $HEALTH_CHECK_RETRIES); do
-  if curl -f http://localhost:3001 2>/dev/null; then
-    echo "Frontend is healthy!"
-    break
-  fi
-  if [ $i -eq $HEALTH_CHECK_RETRIES ]; then
-    echo "ERROR: Frontend health check failed"
-    exit 1
-  fi
-  echo "Waiting for frontend... ($i/$HEALTH_CHECK_RETRIES)"
-  sleep $HEALTH_CHECK_INTERVAL
-done
+if ! health_check "Frontend" "curl -sf http://localhost:3001 >/dev/null 2>&1"; then
+  echo "ERROR: Frontend health check failed"
+  exit 1
+fi
 
 # Step 9: Cleanup old images (opzionale, mantieni ultime 3 versioni)
 echo "[9/9] Cleaning up old images..."


### PR DESCRIPTION
## Summary
- Separate `build-payload` and `build-frontend` into parallel jobs (saves ~3-4 min)
- Optimize Dockerfile layer caching (copy lockfiles before source code)
- Add scoped GitHub Actions cache for each image (`scope=payload`, `scope=frontend`)
- Parallelize image pull in deploy script with background processes
- Implement two-phase health checks (fast 2s retries, then slow 5s fallback)

## Expected Improvement
| Phase | Before | After |
|-------|--------|-------|
| Build Docker | 5-8 min | **2-4 min** |
| Deploy | 3-4 min | **2-3 min** |
| **Total** | 12-18 min | **8-13 min** |

## Test plan
- [ ] CI workflow passes (lint, typecheck, build)
- [ ] CD workflow completes with parallel builds
- [ ] Deploy script runs successfully on VPN server
- [ ] Health checks pass for both services
- [ ] Verify services are accessible after deploy

## Documentation
Added `docs/DEPLOY-OPTIMIZATION-PLAN.md` with full analysis and implementation details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)