### PR TITLE
fix: resolve header flickering during initial scroll on Chrome desktop

### DIFF
--- a/packages/frontend/src/app/globals.css
+++ b/packages/frontend/src/app/globals.css
@@ -166,6 +166,8 @@ body {
 /* Institutional bar: normal state */
 .institutional-bar {
   min-height: 2.75rem; /* 44px = h-11 */
+  will-change: height, min-height, opacity;
+  contain: layout style;
 }
 
 @media (min-width: 768px) {

--- a/packages/frontend/src/components/ScrollDetector.tsx
+++ b/packages/frontend/src/components/ScrollDetector.tsx
@@ -2,19 +2,33 @@
 
 import { useEffect } from 'react'
 
-const SCROLL_THRESHOLD = 50
+// Hysteresis thresholds to prevent flickering feedback loop:
+// The header collapses at 50px but only re-expands below 10px.
+// Without this gap, collapsing the 44px bar shifts layout and can
+// push scrollY back below the threshold, causing rapid toggling.
+const SCROLL_DOWN_THRESHOLD = 50
+const SCROLL_UP_THRESHOLD = 10
 
 export function ScrollDetector() {
   useEffect(() => {
     let ticking = false
+    let isScrolled = false
 
     const handleScroll = () => {
       if (ticking) return
       ticking = true
 
       requestAnimationFrame(() => {
-        const scrolled = window.scrollY > SCROLL_THRESHOLD
-        document.documentElement.toggleAttribute('data-scrolled', scrolled)
+        const scrollY = window.scrollY
+
+        if (!isScrolled && scrollY > SCROLL_DOWN_THRESHOLD) {
+          isScrolled = true
+          document.documentElement.toggleAttribute('data-scrolled', true)
+        } else if (isScrolled && scrollY < SCROLL_UP_THRESHOLD) {
+          isScrolled = false
+          document.documentElement.toggleAttribute('data-scrolled', false)
+        }
+
         ticking = false
       })
     }


### PR DESCRIPTION
## Summary

- Aggiunta **isteresi** allo ScrollDetector: l'header si compatta a 50px di scroll ma si ri-espande solo sotto i 10px. Questo elimina il feedback loop che causava lo sfarfallio rapido su Chrome desktop
- Aggiunte proprietà CSS `will-change` e `contain` alla barra istituzionale per promuovere l'elemento al proprio layer GPU, evitando reflow sul resto della pagina

## Root Cause

Il bug era causato da un **feedback loop di scroll position**:
1. Scroll > 50px → `data-scrolled` attivo → InstitutionalBar collassa (`height: 44px → 0`)
2. Il collasso modifica il layout → `scrollY` può scendere sotto 50px
3. `data-scrolled` rimosso → barra riappare → contenuto si sposta → `scrollY` risale
4. Ciclo rapido = sfarfallio visibile (solo Chrome desktop, che è più aggressivo nel ricalcolo layout)

## Fix

| File | Modifica |
|------|----------|
| `ScrollDetector.tsx` | Isteresi con soglie separate (down: 50px, up: 10px) |
| `globals.css` | `will-change` + `contain: layout style` sulla barra istituzionale |

## Test plan

- [ ] Aprire il sito su Chrome desktop e scrollare lentamente nella prima parte della pagina
- [ ] Verificare che l'header si compatti senza sfarfallio
- [ ] Verificare che scrollando lentamente verso l'alto, la barra riappaia smoothly
- [ ] Testare su Firefox e Safari per assicurarsi che non ci siano regressioni
- [ ] Testare su mobile (il bug era solo desktop, ma verificare che non ci siano side-effects)

Closes #60